### PR TITLE
The direct forward does not exists anymore

### DIFF
--- a/lib/Transip/Model/Forward.php
+++ b/lib/Transip/Model/Forward.php
@@ -12,7 +12,8 @@ namespace Transip\Model;
  */
 class Forward
 {
-    const FORWARDMETHOD_DIRECT = 'direct';
+    const FORWARDMETHOD_MOVEDPERMANENTLY = 'movedPermanently';
+    const FORWARDMETHOD_LOCATION = 'location';
     const FORWARDMETHOD_FRAME  = 'frame';
 
     /**
@@ -30,7 +31,7 @@ class Forward
     public $forwardTo;
 
     /**
-     * Method of forwarding; either Forward::FORWARDMETHOD_DIRECT or Forward::FORWARDMETHOD_FRAME
+     * Method of forwarding; either Forward::FORWARDMETHOD_MOVEDPERMANENTLY, FORWARDMETHOD_LOCATION or Forward::FORWARDMETHOD_FRAME
      *
      * @var string
      */
@@ -88,7 +89,7 @@ class Forward
      * @param string  $forwardSubdomains OPTIONAL Set to true if subdomains should be appended to the target URL.
      * @param string  $forwardEmailTo    OPTIONAL The e-mailaddress all emails to this forward are forwarded to.
      */
-    public function __construct($domainName, $forwardTo, $forwardMethod = 'direct', $frameTitle = '', $frameIcon = '', $forwardEverything = true, $forwardSubdomains = '', $forwardEmailTo = '')
+    public function __construct($domainName, $forwardTo, $forwardMethod = 'movedPermanently', $frameTitle = '', $frameIcon = '', $forwardEverything = true, $forwardSubdomains = '', $forwardEmailTo = '')
     {
         $this->domainName        = $domainName;
         $this->forwardTo         = $forwardTo;


### PR DESCRIPTION
TrasnIP introduced 2 new methods after contacting the support with the following error's this should fix our problems with the forward service. 

```
An Exception occured. Code: 0, message: De ingevulde waarde behoort niet tot de mogelijkheden. (timestamp: 0.34892000 1405332181
```

```
Er is een interne fout opgetreden, neem a.u.b. contact op met support. (UNDEFINED) (timestamp: 0.40064900 1404829739)
```

```
Er is een interne fout opgetreden, neem a.u.b. contact op met support. (OBJECT_SHOULD_NOT_BE_NULL) (timestamp: 0.23617300 1404829792)
```
